### PR TITLE
android: app: Fix jniLibs folder capitalization

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -124,7 +124,7 @@ android {
         main.java.srcDirs += 'src/legacy/kotlin'
 
         main.java.srcDirs += 'src/engine/kotlin'
-        main.jniLibs.srcDirs += 'src/engine/jnilibs'
+        main.jniLibs.srcDirs += 'src/engine/jniLibs'
 
         debug.java.srcDirs += 'src/mock/kotlin'
 


### PR DESCRIPTION
Hi @kar, congrats on releasing Blokada 5! The new UI looks sick, I'm already enjoying it :grin: (Blokada 4 had this weird stutter-expand effect as if it was recursively inflating UI elements in-place).

When trying it out locally all native libraries went missing from the APK because of a pathname capitalization issue; this PR fixes that.

I can't help but ask a burning question, that doesn't really fit in an issue. Initially I was excited when seeing Rust in Blokada 4, assuming it was used for maximum efficiency (which seems to be a common theme around blocklists) but it's just for boringtun. Now with Blokada 5 the filters made its way into Rust, but remain in Kotlin as well. This area of doing the filtering (on Android) in Rust is still under construction?
